### PR TITLE
#include <filesys/filesys.h>

### DIFF
--- a/.gdb_history
+++ b/.gdb_history
@@ -1,0 +1,2 @@
+quit
+quit

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,11 @@
 {
     "files.associations": {
-        "numbers": "c"
+        "numbers": "c",
+        "*.inc": "c",
+        "*.tcc": "c",
+        "string_view": "c",
+        "atomic": "c",
+        "process.h": "c",
+        "synch.h": "c"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,7 @@
         "process.h": "c",
         "synch.h": "c",
         "palloc.h": "c",
-        "thread.h": "c"
+        "thread.h": "c",
+        "filesys.h": "c"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,8 @@
         "string_view": "c",
         "atomic": "c",
         "process.h": "c",
-        "synch.h": "c"
+        "synch.h": "c",
+        "palloc.h": "c",
+        "thread.h": "c"
     }
 }

--- a/do.sh
+++ b/do.sh
@@ -4,5 +4,5 @@ make
 cd build
 source ../../activate
 pintos-mkdisk filesys.dsk 10
-# pintos --fs-disk filesys.dsk -p tests/userprog/read-normal:read-normal -p ../../tests/userprog/sample.txt:sample.txt -- -q -f run read-normal
-pintos --fs-disk filesys.dsk -p tests/userprog/read-normal:read-normal -p ../../tests/userprog/sample.txt:sample.txt --gdb -- -f run read-normal
+pintos --fs-disk filesys.dsk -p tests/userprog/read-normal:read-normal -p ../../tests/userprog/sample.txt:sample.txt -- -q -f run read-normal
+# pintos --fs-disk filesys.dsk -p tests/userprog/read-normal:read-normal -p ../../tests/userprog/sample.txt:sample.txt --gdb -- -f run read-normal

--- a/do.sh
+++ b/do.sh
@@ -4,5 +4,5 @@ make
 cd build
 source ../../activate
 pintos-mkdisk filesys.dsk 10
-pintos --fs-disk filesys.dsk -p tests/userprog/open-twice:open-twice -p ../../tests/userprog/sample.txt:sample.txt -- -q -f run open-twice
-# pintos --fs-disk filesys.dsk -p tests/userprog/open-twice:open-twice --gdb -- -f run 'open-twice'
+# pintos --fs-disk filesys.dsk -p tests/userprog/open-normal:open-normal -p ../../tests/userprog/sample.txt:sample.txt -- -q -f run open-normal
+pintos --fs-disk filesys.dsk -p tests/userprog/open-normal:open-normal -p ../../tests/userprog/sample.txt:sample.txt --gdb -- -f run open-normal

--- a/do.sh
+++ b/do.sh
@@ -4,5 +4,5 @@ make
 cd build
 source ../../activate
 pintos-mkdisk filesys.dsk 10
-# pintos --fs-disk filesys.dsk -p tests/userprog/open-normal:open-normal -p ../../tests/userprog/sample.txt:sample.txt -- -q -f run open-normal
-pintos --fs-disk filesys.dsk -p tests/userprog/open-normal:open-normal -p ../../tests/userprog/sample.txt:sample.txt --gdb -- -f run open-normal
+# pintos --fs-disk filesys.dsk -p tests/userprog/read-normal:read-normal -p ../../tests/userprog/sample.txt:sample.txt -- -q -f run read-normal
+pintos --fs-disk filesys.dsk -p tests/userprog/read-normal:read-normal -p ../../tests/userprog/sample.txt:sample.txt --gdb -- -f run read-normal

--- a/do.sh
+++ b/do.sh
@@ -4,5 +4,5 @@ make
 cd build
 source ../../activate
 pintos-mkdisk filesys.dsk 10
-# pintos --fs-disk filesys.dsk -p tests/userprog/open-twice:open-twice -- -q -f run 'open-twice sample.txt'
-pintos --fs-disk filesys.dsk -p tests/userprog/open-twice:open-twice --gdb -- -f run 'open-twice sample.txt'
+pintos --fs-disk filesys.dsk -p tests/userprog/open-twice:open-twice -p ../../tests/userprog/sample.txt:sample.txt -- -q -f run open-twice
+# pintos --fs-disk filesys.dsk -p tests/userprog/open-twice:open-twice --gdb -- -f run 'open-twice'

--- a/do.sh
+++ b/do.sh
@@ -4,5 +4,5 @@ make
 cd build
 source ../../activate
 pintos-mkdisk filesys.dsk 10
-pintos --fs-disk filesys.dsk -p tests/userprog/args-many:args-many -- -q -f run 'args-many a b c d e f g h i j k l m n o p q r s t u v'
-# pintos --fs-disk filesys.dsk -p tests/userprog/args-single:args-single --gdb -- -f run 'args-single onearg'
+# pintos --fs-disk filesys.dsk -p tests/userprog/open-twice:open-twice -- -q -f run 'open-twice sample.txt'
+pintos --fs-disk filesys.dsk -p tests/userprog/open-twice:open-twice --gdb -- -f run 'open-twice sample.txt'

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -6,6 +6,8 @@
 #include <stdint.h>
 
 #include "threads/interrupt.h"
+#include "threads/synch.h" // fd_lock을 스레드마다 구현하기 위함
+
 #ifdef VM
 #include "vm/vm.h"
 #endif
@@ -22,6 +24,10 @@ enum thread_status {
    You can redefine this to whatever type you like. */
 typedef int tid_t;
 #define TID_ERROR ((tid_t)-1) /* Error value for tid_t. */
+
+/* PID 전용 Identifier Type*/
+typedef int pid_t;
+#define PID_ERROR ((pid_t)-1) /* Error value for tid_t. */
 
 /* Thread priorities. */
 #define PRI_MIN 0      /* Lowest priority. */
@@ -112,6 +118,9 @@ struct thread {
     // int exit_status;              // 프로세스 종료시 exit status 코드 저장
     // struct semaphore *child_lock; // 복수의 child를 기다려야 할 수 있으니 이름은 lock이지만 semaphore (0으로 init 필요)
     // bool already_waited;          // 해당 child에 대한 process_wait()이 이미 호출되었다면 true (False로 init 필요)
+
+    struct file **fd_table; // File Descriptor Table ; init_thread에서 한번 초기화
+    struct lock fd_lock;    // Allocate_fd()에서 사용되는 락, per thread
 
 #endif
 #ifdef VM

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -109,6 +109,7 @@ struct thread {
     struct list_elem elem; /* 원래 포함되어 있는, 가장 기본적인 thread elem */
 
 #ifdef USERPROG
+
     /* 기본적으로 포함되어있는 멤버 */
     uint64_t *pml4; /* Page map level 4 */
 
@@ -119,8 +120,8 @@ struct thread {
     // struct semaphore *child_lock; // 복수의 child를 기다려야 할 수 있으니 이름은 lock이지만 semaphore (0으로 init 필요)
     // bool already_waited;          // 해당 child에 대한 process_wait()이 이미 호출되었다면 true (False로 init 필요)
 
-    struct file **fd_table; // File Descriptor Table ; init_thread에서 한번 초기화
     struct lock fd_lock;    // Allocate_fd()에서 사용되는 락, per thread
+    struct file **fd_table; // File Descriptor Table ; init_thread에서 한번 초기화
 
 #endif
 #ifdef VM

--- a/include/threads/vaddr.h
+++ b/include/threads/vaddr.h
@@ -2,8 +2,8 @@
 #define THREADS_VADDR_H
 
 #include <debug.h>
-#include <stdint.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #include "threads/loader.h"
 
@@ -15,21 +15,21 @@
 #define BITMASK(SHIFT, CNT) (((1ul << (CNT)) - 1) << (SHIFT))
 
 /* Page offset (bits 0:12). */
-#define PGSHIFT 0                          /* Index of first offset bit. */
-#define PGBITS  12                         /* Number of offset bits. */
-#define PGSIZE  (1 << PGBITS)              /* Bytes in a page. */
-#define PGMASK  BITMASK(PGSHIFT, PGBITS)   /* Page offset bits (0:12). */
+#define PGSHIFT 0                       /* Index of first offset bit. */
+#define PGBITS 12                       /* Number of offset bits. */
+#define PGSIZE (1 << PGBITS)            /* Bytes in a page. */
+#define PGMASK BITMASK(PGSHIFT, PGBITS) /* Page offset bits (0:12). */
 
 /* Offset within a page. */
-#define pg_ofs(va) ((uint64_t) (va) & PGMASK)
+#define pg_ofs(va) ((uint64_t)(va)&PGMASK)
 
-#define pg_no(va) ((uint64_t) (va) >> PGBITS)
+#define pg_no(va) ((uint64_t)(va) >> PGBITS)
 
 /* Round up to nearest page boundary. */
-#define pg_round_up(va) ((void *) (((uint64_t) (va) + PGSIZE - 1) & ~PGMASK))
+#define pg_round_up(va) ((void *)(((uint64_t)(va) + PGSIZE - 1) & ~PGMASK))
 
 /* Round down to nearest page boundary. */
-#define pg_round_down(va) (void *) ((uint64_t) (va) & ~PGMASK)
+#define pg_round_down(va) (void *)((uint64_t)(va) & ~PGMASK)
 
 /* Kernel virtual address start */
 #define KERN_BASE LOADER_KERN_BASE
@@ -46,14 +46,14 @@
 // FIXME: add checking
 /* Returns kernel virtual address at which physical address PADDR
  *  is mapped. */
-#define ptov(paddr) ((void *) (((uint64_t) paddr) + KERN_BASE))
+#define ptov(paddr) ((void *)(((uint64_t)paddr) + KERN_BASE))
 
 /* Returns physical address at which kernel virtual address VADDR
  * is mapped. */
-#define vtop(vaddr) \
-({ \
-	ASSERT(is_kernel_vaddr(vaddr)); \
-	((uint64_t) (vaddr) - (uint64_t) KERN_BASE);\
-})
+#define vtop(vaddr)                                                                                                                                                                                    \
+    ({                                                                                                                                                                                                 \
+        ASSERT(is_kernel_vaddr(vaddr));                                                                                                                                                                \
+        ((uint64_t)(vaddr) - (uint64_t)KERN_BASE);                                                                                                                                                     \
+    })
 
 #endif /* threads/vaddr.h */

--- a/lib/user/syscall.c
+++ b/lib/user/syscall.c
@@ -1,196 +1,99 @@
-#include <syscall.h>
-#include <stdint.h>
 #include "../syscall-nr.h"
+#include <stdint.h>
+#include <syscall.h>
 
-__attribute__((always_inline))
-static __inline int64_t syscall (uint64_t num_, uint64_t a1_, uint64_t a2_,
-		uint64_t a3_, uint64_t a4_, uint64_t a5_, uint64_t a6_) {
-	int64_t ret;
-	register uint64_t *num asm ("rax") = (uint64_t *) num_;
-	register uint64_t *a1 asm ("rdi") = (uint64_t *) a1_;
-	register uint64_t *a2 asm ("rsi") = (uint64_t *) a2_;
-	register uint64_t *a3 asm ("rdx") = (uint64_t *) a3_;
-	register uint64_t *a4 asm ("r10") = (uint64_t *) a4_;
-	register uint64_t *a5 asm ("r8") = (uint64_t *) a5_;
-	register uint64_t *a6 asm ("r9") = (uint64_t *) a6_;
+__attribute__((always_inline)) static __inline int64_t syscall(uint64_t num_, uint64_t a1_, uint64_t a2_, uint64_t a3_, uint64_t a4_, uint64_t a5_, uint64_t a6_) {
+    int64_t ret;
+    register uint64_t *num asm("rax") = (uint64_t *)num_;
+    register uint64_t *a1 asm("rdi") = (uint64_t *)a1_;
+    register uint64_t *a2 asm("rsi") = (uint64_t *)a2_;
+    register uint64_t *a3 asm("rdx") = (uint64_t *)a3_;
+    register uint64_t *a4 asm("r10") = (uint64_t *)a4_;
+    register uint64_t *a5 asm("r8") = (uint64_t *)a5_;
+    register uint64_t *a6 asm("r9") = (uint64_t *)a6_;
 
-	__asm __volatile(
-			"mov %1, %%rax\n"
-			"mov %2, %%rdi\n"
-			"mov %3, %%rsi\n"
-			"mov %4, %%rdx\n"
-			"mov %5, %%r10\n"
-			"mov %6, %%r8\n"
-			"mov %7, %%r9\n"
-			"syscall\n"
-			: "=a" (ret)
-			: "g" (num), "g" (a1), "g" (a2), "g" (a3), "g" (a4), "g" (a5), "g" (a6)
-			: "cc", "memory");
-	return ret;
+    __asm __volatile("mov %1, %%rax\n"
+                     "mov %2, %%rdi\n"
+                     "mov %3, %%rsi\n"
+                     "mov %4, %%rdx\n"
+                     "mov %5, %%r10\n"
+                     "mov %6, %%r8\n"
+                     "mov %7, %%r9\n"
+                     "syscall\n"
+                     : "=a"(ret)
+                     : "g"(num), "g"(a1), "g"(a2), "g"(a3), "g"(a4), "g"(a5), "g"(a6)
+                     : "cc", "memory");
+    return ret;
 }
 
 /* Invokes syscall NUMBER, passing no arguments, and returns the
    return value as an `int'. */
-#define syscall0(NUMBER) ( \
-		syscall(((uint64_t) NUMBER), 0, 0, 0, 0, 0, 0))
+#define syscall0(NUMBER) (syscall(((uint64_t)NUMBER), 0, 0, 0, 0, 0, 0))
 
 /* Invokes syscall NUMBER, passing argument ARG0, and returns the
    return value as an `int'. */
-#define syscall1(NUMBER, ARG0) ( \
-		syscall(((uint64_t) NUMBER), \
-			((uint64_t) ARG0), 0, 0, 0, 0, 0))
+#define syscall1(NUMBER, ARG0) (syscall(((uint64_t)NUMBER), ((uint64_t)ARG0), 0, 0, 0, 0, 0))
 /* Invokes syscall NUMBER, passing arguments ARG0 and ARG1, and
    returns the return value as an `int'. */
-#define syscall2(NUMBER, ARG0, ARG1) ( \
-		syscall(((uint64_t) NUMBER), \
-			((uint64_t) ARG0), \
-			((uint64_t) ARG1), \
-			0, 0, 0, 0))
+#define syscall2(NUMBER, ARG0, ARG1) (syscall(((uint64_t)NUMBER), ((uint64_t)ARG0), ((uint64_t)ARG1), 0, 0, 0, 0))
 
-#define syscall3(NUMBER, ARG0, ARG1, ARG2) ( \
-		syscall(((uint64_t) NUMBER), \
-			((uint64_t) ARG0), \
-			((uint64_t) ARG1), \
-			((uint64_t) ARG2), 0, 0, 0))
+#define syscall3(NUMBER, ARG0, ARG1, ARG2) (syscall(((uint64_t)NUMBER), ((uint64_t)ARG0), ((uint64_t)ARG1), ((uint64_t)ARG2), 0, 0, 0))
 
-#define syscall4(NUMBER, ARG0, ARG1, ARG2, ARG3) ( \
-		syscall(((uint64_t *) NUMBER), \
-			((uint64_t) ARG0), \
-			((uint64_t) ARG1), \
-			((uint64_t) ARG2), \
-			((uint64_t) ARG3), 0, 0))
+#define syscall4(NUMBER, ARG0, ARG1, ARG2, ARG3) (syscall(((uint64_t *)NUMBER), ((uint64_t)ARG0), ((uint64_t)ARG1), ((uint64_t)ARG2), ((uint64_t)ARG3), 0, 0))
 
-#define syscall5(NUMBER, ARG0, ARG1, ARG2, ARG3, ARG4) ( \
-		syscall(((uint64_t) NUMBER), \
-			((uint64_t) ARG0), \
-			((uint64_t) ARG1), \
-			((uint64_t) ARG2), \
-			((uint64_t) ARG3), \
-			((uint64_t) ARG4), \
-			0))
-void
-halt (void) {
-	syscall0 (SYS_HALT);
-	NOT_REACHED ();
+#define syscall5(NUMBER, ARG0, ARG1, ARG2, ARG3, ARG4) (syscall(((uint64_t)NUMBER), ((uint64_t)ARG0), ((uint64_t)ARG1), ((uint64_t)ARG2), ((uint64_t)ARG3), ((uint64_t)ARG4), 0))
+void halt(void) {
+    syscall0(SYS_HALT);
+    NOT_REACHED();
 }
 
-void
-exit (int status) {
-	syscall1 (SYS_EXIT, status);
-	NOT_REACHED ();
+void exit(int status) {
+    syscall1(SYS_EXIT, status);
+    NOT_REACHED();
 }
 
-pid_t
-fork (const char *thread_name){
-	return (pid_t) syscall1 (SYS_FORK, thread_name);
-}
+pid_t fork(const char *thread_name) { return (pid_t)syscall1(SYS_FORK, thread_name); }
 
-int
-exec (const char *file) {
-	return (pid_t) syscall1 (SYS_EXEC, file);
-}
+int exec(const char *file) { return (pid_t)syscall1(SYS_EXEC, file); }
 
-int
-wait (pid_t pid) {
-	return syscall1 (SYS_WAIT, pid);
-}
+int wait(pid_t pid) { return syscall1(SYS_WAIT, pid); }
 
-bool
-create (const char *file, unsigned initial_size) {
-	return syscall2 (SYS_CREATE, file, initial_size);
-}
+bool create(const char *file, unsigned initial_size) { return syscall2(SYS_CREATE, file, initial_size); }
 
-bool
-remove (const char *file) {
-	return syscall1 (SYS_REMOVE, file);
-}
+bool remove(const char *file) { return syscall1(SYS_REMOVE, file); }
 
-int
-open (const char *file) {
-	return syscall1 (SYS_OPEN, file);
-}
+int open(const char *file) { return syscall1(SYS_OPEN, file); }
 
-int
-filesize (int fd) {
-	return syscall1 (SYS_FILESIZE, fd);
-}
+int filesize(int fd) { return syscall1(SYS_FILESIZE, fd); }
 
-int
-read (int fd, void *buffer, unsigned size) {
-	return syscall3 (SYS_READ, fd, buffer, size);
-}
+int read(int fd, void *buffer, unsigned size) { return syscall3(SYS_READ, fd, buffer, size); }
 
-int
-write (int fd, const void *buffer, unsigned size) {
-	return syscall3 (SYS_WRITE, fd, buffer, size);
-}
+int write(int fd, const void *buffer, unsigned size) { return syscall3(SYS_WRITE, fd, buffer, size); }
 
-void
-seek (int fd, unsigned position) {
-	syscall2 (SYS_SEEK, fd, position);
-}
+void seek(int fd, unsigned position) { syscall2(SYS_SEEK, fd, position); }
 
-unsigned
-tell (int fd) {
-	return syscall1 (SYS_TELL, fd);
-}
+unsigned tell(int fd) { return syscall1(SYS_TELL, fd); }
 
-void
-close (int fd) {
-	syscall1 (SYS_CLOSE, fd);
-}
+void close(int fd) { syscall1(SYS_CLOSE, fd); }
 
-int
-dup2 (int oldfd, int newfd){
-	return syscall2 (SYS_DUP2, oldfd, newfd);
-}
+int dup2(int oldfd, int newfd) { return syscall2(SYS_DUP2, oldfd, newfd); }
 
-void *
-mmap (void *addr, size_t length, int writable, int fd, off_t offset) {
-	return (void *) syscall5 (SYS_MMAP, addr, length, writable, fd, offset);
-}
+void *mmap(void *addr, size_t length, int writable, int fd, off_t offset) { return (void *)syscall5(SYS_MMAP, addr, length, writable, fd, offset); }
 
-void
-munmap (void *addr) {
-	syscall1 (SYS_MUNMAP, addr);
-}
+void munmap(void *addr) { syscall1(SYS_MUNMAP, addr); }
 
-bool
-chdir (const char *dir) {
-	return syscall1 (SYS_CHDIR, dir);
-}
+bool chdir(const char *dir) { return syscall1(SYS_CHDIR, dir); }
 
-bool
-mkdir (const char *dir) {
-	return syscall1 (SYS_MKDIR, dir);
-}
+bool mkdir(const char *dir) { return syscall1(SYS_MKDIR, dir); }
 
-bool
-readdir (int fd, char name[READDIR_MAX_LEN + 1]) {
-	return syscall2 (SYS_READDIR, fd, name);
-}
+bool readdir(int fd, char name[READDIR_MAX_LEN + 1]) { return syscall2(SYS_READDIR, fd, name); }
 
-bool
-isdir (int fd) {
-	return syscall1 (SYS_ISDIR, fd);
-}
+bool isdir(int fd) { return syscall1(SYS_ISDIR, fd); }
 
-int
-inumber (int fd) {
-	return syscall1 (SYS_INUMBER, fd);
-}
+int inumber(int fd) { return syscall1(SYS_INUMBER, fd); }
 
-int
-symlink (const char* target, const char* linkpath) {
-	return syscall2 (SYS_SYMLINK, target, linkpath);
-}
+int symlink(const char *target, const char *linkpath) { return syscall2(SYS_SYMLINK, target, linkpath); }
 
-int
-mount (const char *path, int chan_no, int dev_no) {
-	return syscall3 (SYS_MOUNT, path, chan_no, dev_no);
-}
+int mount(const char *path, int chan_no, int dev_no) { return syscall3(SYS_MOUNT, path, chan_no, dev_no); }
 
-int
-umount (const char *path) {
-	return syscall1 (SYS_UMOUNT, path);
-}
+int umount(const char *path) { return syscall1(SYS_UMOUNT, path); }

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -423,14 +423,16 @@ static void init_thread(struct thread *t, const char *name, int priority) {
     list_init(&t->donations);        // 우선순위를 기부받는다면 저장하는 리스트
     t->magic = THREAD_MAGIC;
 
-    /* 유저 프로그램에 의해서 생성될 경우 별도의 struct thread 멤버들이 있으며, 해당 멤버들을 초기화 해줘야 함 */
-    // #ifdef USERPROG
+/* 유저 프로그램에 의해서 생성될 경우 별도의 struct thread 멤버들이 있으며, 해당 멤버들을 초기화 해줘야 함 */
+#ifdef USERPROG
+
     //     list_init(&t->children); // 자세한 사항은 thread.h 참고 요망
     //     t->exit_status = 0;
     //     t->child_lock = (struct semaphore *)malloc(sizeof(struct semaphore));
     //     sema_init(t->child_lock, 0);
     //     t->already_waited = false;
-    // #endif
+
+#endif
 }
 
 /* CPU를 할당받을 다음 스레드를 고르는 함수 (idle thread가 여기서 적용) */

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -143,6 +143,8 @@ tid_t thread_create(const char *name, int priority, thread_func *function, void 
     /* 스레드 초기화 작업 */
     init_thread(t, name, priority);
     tid = t->tid = allocate_tid();
+    t->fd_table = (struct file **)palloc_get_page(0); // User-side에 0으로 초기화된 페이지를 새로 Allocate
+    lock_init(&t->fd_lock);
 
     /* 커널 스레드가 ready_list에 있다면 호출, Function/Aux 값을 부여 */
     t->tf.rip = (uintptr_t)kernel_thread;

--- a/threads/thread.c
+++ b/threads/thread.c
@@ -143,8 +143,11 @@ tid_t thread_create(const char *name, int priority, thread_func *function, void 
     /* 스레드 초기화 작업 */
     init_thread(t, name, priority);
     tid = t->tid = allocate_tid();
+
+#ifdef USERPROG
     t->fd_table = (struct file **)palloc_get_page(0); // User-side에 0으로 초기화된 페이지를 새로 Allocate
     lock_init(&t->fd_lock);
+#endif
 
     /* 커널 스레드가 ready_list에 있다면 호출, Function/Aux 값을 부여 */
     t->tf.rip = (uintptr_t)kernel_thread;

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -220,7 +220,7 @@ int process_exec(void *f_name) {
 int process_wait(tid_t child_tid) {
 
     int i;
-    for (i = 0; i < 2000000000; i++) {
+    for (i = 0; i < 1300000000; i++) {
         // 야매로 무한루프 돌리기
     }
     return -1;

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -221,7 +221,7 @@ int process_wait(tid_t child_tid) {
 
     int i;
     for (i = 0; i < 2000000000; i++) {
-        //야매로 무한루프 돌리기
+        // 야매로 무한루프 돌리기
     }
     return -1;
 

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -32,9 +32,7 @@ static void __do_fork(void *);
 static void process_init(void) {
     struct thread *current = thread_current();
 
-    /* 과연 이걸 여기에 넣는게 맞는것인가 */
-    // thread_current()->fd_table = (struct file **)palloc_get_page(0); // User-side에 0으로 초기화된 페이지를 새로 Allocate
-    // lock_init(&(thread_current()->fd_lock));
+    /* 여기 뭔가 채워넣어야 할 것 같은 기분 (현재 아무것도 안하는 함수) */
 }
 
 /* 최초의 user-side 프로그램인 initd를 시작하는 함수로, 해당 TID를 반환.

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -23,16 +23,25 @@
 #include "vm/vm.h"
 #endif
 
+/* 기존 prototype들 */
 static void process_cleanup(void);
 static bool load(const char *file_name, struct intr_frame *if_);
 static void initd(void *f_name);
 static void __do_fork(void *);
+
+/* 새로운 함수 프로로타입 */
+void parse_argv_to_stack(char **argv, struct intr_frame *if_);
 
 /* 최초의 유저 프로세스인 initd를 포함한 모든 프로세스를 초기화 하는 공통 함수 */
 static void process_init(void) {
     struct thread *current = thread_current();
 
     /* 여기 뭔가 채워넣어야 할 것 같은 기분 (현재 아무것도 안하는 함수) */
+
+    // /* 스레드에 페이지 부여 */
+    // current = palloc_get_page(PAL_ZERO);
+    // if (current == NULL)
+    //     return TID_ERROR;
 }
 
 /* 최초의 user-side 프로그램인 initd를 시작하는 함수로, 해당 TID를 반환.
@@ -383,7 +392,7 @@ static bool load(const char *file_name, struct intr_frame *if_) {
     char *token, *save_ptr;
 
     for (token = strtok_r(file_name, " ", &save_ptr); token != NULL; token = strtok_r(NULL, " ", &save_ptr)) {
-        // printf("%s\n", token);
+        printf("%s\n", token);
         argv[argc] = token;
         argc++;
 
@@ -467,6 +476,28 @@ static bool load(const char *file_name, struct intr_frame *if_) {
     if_->rip = ehdr.e_entry;
 
     /* 파싱된 나머지 argv, argc 값들을 스택에 추가 (여기서부터 끝까지) */
+    parse_argv_to_stack(argv, if_);
+
+    /* 성공했다고 회신 예정이니 값 변경 */
+    success = true;
+
+done:
+    /* We arrive here whether the load is successful or not. */
+    file_close(file);
+    return success;
+}
+
+void parse_argv_to_stack(char **argv, struct intr_frame *if_) {
+
+    int i, j;
+    int argc = 0;
+    char **temp_argv = argv;
+
+    /* (0) Temp_argv 더블포인터로 argv 이동하되 값을 직접 건드리지 않고 작업 */
+    while (*temp_argv) {
+        argc++;
+        temp_argv++;
+    }
 
     // (1) rsp 스택 포인터를 이동시키는 임시 포인터 선언 ; 현재 intr_frame의 스택 포인터 %rsp를 가리키면서 출발 (rsp 자체가 포인터니까 더블포인터로 구현)
     char **stack_ptr = (char **)if_->rsp;
@@ -486,8 +517,8 @@ static bool load(const char *file_name, struct intr_frame *if_) {
 
     // (4) 1번에서 argv 배열을 각 요소의 메모리 위치를 가리키는 배열포인터로 전환했으니, 이제 각 값들을 다시 스택에 추가
     stack_ptr -= (argc + 1) * sizeof(char *); // 각 포인터는 char 크기 ; 그만큼 스택 임시포인터 하향 조정 ; argc + 1은 NULL 값을 추가하기 위한 선제 조치
-    for (i = 0; i < argc; i++) {              // 이제 반복문으로 argv 포인터 배열의 각 요소들을 stack_ptr에 추가
-        stack_ptr[i] = argv[i];               // 공간을 확보한 stack_ptr에서부터 char* 크기만큼 i번 이동, 각 위치에 argv[i]의 포인터를 저장
+    for (j = 0; j < argc; j++) {              // 이제 반복문으로 argv 포인터 배열의 각 요소들을 stack_ptr에 추가
+        stack_ptr[j] = argv[j];               // 공간을 확보한 stack_ptr에서부터 char* 크기만큼 i번 이동, 각 위치에 argv[i]의 포인터를 저장
     }
     stack_ptr[argc] = NULL; // argc가 4라면, argv[4]의 위치에 NULL Terminator를 추가 (x86-64 컨벤션)
 
@@ -501,14 +532,6 @@ static bool load(const char *file_name, struct intr_frame *if_) {
 
     // (7) intr_frame의 유저 스택 포인터 rsp 값도 업데이트
     if_->rsp = stack_ptr;
-
-    /* 성공했다고 회신 예정이니 값 변경 */
-    success = true;
-
-done:
-    /* We arrive here whether the load is successful or not. */
-    file_close(file);
-    return success;
 }
 
 /* Checks whether PHDR describes a valid, loadable segment in

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -8,6 +8,7 @@
 #include "threads/interrupt.h"
 #include "threads/mmu.h"
 #include "threads/palloc.h"
+#include "threads/synch.h" // fd_lock을 스레드마다 구현하기 위함
 #include "threads/thread.h"
 #include "threads/vaddr.h"
 #include "userprog/gdt.h"
@@ -30,7 +31,10 @@ static void __do_fork(void *);
 /* 최초의 유저 프로세스인 initd를 포함한 모든 프로세스를 초기화 하는 공통 함수 */
 static void process_init(void) {
     struct thread *current = thread_current();
-    // 여기에 결국 뭔가 넣어야 함 (이대로는 아무런 의미가 없음 ㅎ);
+
+    /* 과연 이걸 여기에 넣는게 맞는것인가 */
+    thread_current()->fd_table = (struct file **)palloc_get_page(0); // User-side에 0으로 초기화된 페이지를 새로 Allocate
+    lock_init(&(thread_current()->fd_lock));
 }
 
 /* 최초의 user-side 프로그램인 initd를 시작하는 함수로, 해당 TID를 반환.
@@ -117,7 +121,10 @@ static void __do_fork(void *aux) {
     struct intr_frame if_;
     struct thread *parent = (struct thread *)aux;
     struct thread *current = thread_current();
+
     /* TODO: somehow pass the parent_if. (i.e. process_fork()'s if_) */
+    // 여기서 struct thread의 **fd_table 값도 child process에게 줘야 함
+
     struct intr_frame *parent_if;
     bool succ = true;
 

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -33,8 +33,8 @@ static void process_init(void) {
     struct thread *current = thread_current();
 
     /* 과연 이걸 여기에 넣는게 맞는것인가 */
-    thread_current()->fd_table = (struct file **)palloc_get_page(0); // User-side에 0으로 초기화된 페이지를 새로 Allocate
-    lock_init(&(thread_current()->fd_lock));
+    // thread_current()->fd_table = (struct file **)palloc_get_page(0); // User-side에 0으로 초기화된 페이지를 새로 Allocate
+    // lock_init(&(thread_current()->fd_lock));
 }
 
 /* 최초의 user-side 프로그램인 initd를 시작하는 함수로, 해당 TID를 반환.

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -392,7 +392,6 @@ static bool load(const char *file_name, struct intr_frame *if_) {
     char *token, *save_ptr;
 
     for (token = strtok_r(file_name, " ", &save_ptr); token != NULL; token = strtok_r(NULL, " ", &save_ptr)) {
-        printf("%s\n", token);
         argv[argc] = token;
         argc++;
 

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -1,10 +1,10 @@
 #include "userprog/syscall.h"
+#include "filesys/filesys.h" // 씨발
 #include "intrinsic.h"
 #include "threads/flags.h"
 #include "threads/interrupt.h"
 #include "threads/loader.h"
 #include "threads/thread.h"
-
 #include "userprog/gdt.h"
 #include <stdio.h>
 #include <syscall-nr.h>


### PR DESCRIPTION
pass tests/threads/priority-donate-chain
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
FAIL tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
FAIL tests/userprog/write-boundary
FAIL tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
FAIL tests/userprog/fork-once
FAIL tests/userprog/fork-multiple
FAIL tests/userprog/fork-recursive
FAIL tests/userprog/fork-read
FAIL tests/userprog/fork-close
FAIL tests/userprog/fork-boundary
FAIL tests/userprog/exec-once
FAIL tests/userprog/exec-arg
FAIL tests/userprog/exec-boundary
FAIL tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
FAIL tests/userprog/exec-read
FAIL tests/userprog/wait-simple
FAIL tests/userprog/wait-twice
FAIL tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
FAIL tests/userprog/multi-recurse
FAIL tests/userprog/multi-child-fd
FAIL tests/userprog/rox-simple
FAIL tests/userprog/rox-child
FAIL tests/userprog/rox-multichild
FAIL tests/userprog/bad-read
FAIL tests/userprog/bad-write
FAIL tests/userprog/bad-read2
FAIL tests/userprog/bad-write2
FAIL tests/userprog/bad-jump
FAIL tests/userprog/bad-jump2
pass tests/filesys/base/lg-create
FAIL tests/filesys/base/lg-full
FAIL tests/filesys/base/lg-random
FAIL tests/filesys/base/lg-seq-block
FAIL tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
FAIL tests/filesys/base/sm-full
FAIL tests/filesys/base/sm-random
FAIL tests/filesys/base/sm-seq-block
FAIL tests/filesys/base/sm-seq-random
FAIL tests/filesys/base/syn-read
FAIL tests/filesys/base/syn-remove
FAIL tests/filesys/base/syn-write
FAIL tests/userprog/no-vm/multi-oom
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
40 of 95 tests failed.